### PR TITLE
fix: Skip inlining Git LFS placeholders (fix #9714) (#9795)

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -53,8 +53,10 @@ Specify the directory to nest generated assets under (relative to `build.outDir`
 
 Imported or referenced assets that are smaller than this threshold will be inlined as base64 URLs to avoid extra http requests. Set to `0` to disable inlining altogether.
 
+Git LFS placeholders are automatically excluded from inlining because they do not contain the content of the file they represent.
+
 ::: tip Note
-If you specify `build.lib`, `build.assetsInlineLimit` will be ignored and assets will always be inlined, regardless of file size.
+If you specify `build.lib`, `build.assetsInlineLimit` will be ignored and assets will always be inlined, regardless of file size or being a Git LFS placeholder.
 :::
 
 ## build.cssCodeSplit

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -26,6 +26,8 @@ The behavior is similar to webpack's `file-loader`. The difference is that the i
 
 - Assets smaller in bytes than the [`assetsInlineLimit` option](/config/build-options.md#build-assetsinlinelimit) will be inlined as base64 data URLs.
 
+- Git LFS placeholders are automatically excluded from inlining because they do not contain the content of the file they represent. To get inlining, make sure to download the file contents via Git LFS before building.
+
 ### Explicit URL Imports
 
 Assets that are not included in the internal list or in `assetsInclude`, can be explicitly imported as a URL using the `?url` suffix. This is useful, for example, to import [Houdini Paint Worklets](https://houdini.how/usage).


### PR DESCRIPTION
close #75 