### PR TITLE
docs: fix typo and unresolvable link in Lightning CSS guide (#13609)

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -266,12 +266,12 @@ npm add -D lightningcss
 
 If enabled, CSS files will be processed by Lightning CSS instead of PostCSS. To configure it, you can pass Lightining CSS options to the [`css.lightingcss`](../config/shared-options.md#css-lightningcss) config option.
 
-To configue CSS Modules, you'll use [`css.lightningcss.cssModules`](https://lightningcss.dev/css-modules.html) instead of [`css.modules`](../config/shared-options.md#css-modules) (wich configures the way PostCSS handles CSS modules).
+To configure CSS Modules, you'll use [`css.lightningcss.cssModules`](https://lightningcss.dev/css-modules.html) instead of [`css.modules`](../config/shared-options.md#css-modules) (which configures the way PostCSS handles CSS modules).
 
 By default, Vite uses esbuild to minify CSS. Lightning CSS can also be used as the CSS minifier with [`build.cssMinify: 'lightningcss'`](../config/build-options.md#css-minify).
 
 ::: tip NOTE
-[CSS Pre-processors](/#css-pre-processors) aren't supported when using Lightning CSS.
+[CSS Pre-processors](#css-pre-processors) aren't supported when using Lightning CSS.
 :::
 
 ## Static Assets


### PR DESCRIPTION
close #433 