### PR TITLE
fix!: put manifest files in .vite directory by default (#14230)

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -163,7 +163,7 @@ Build as a library. `entry` is required since the library cannot use HTML as ent
 - **Default:** `false`
 - **Related:** [Backend Integration](/guide/backend-integration)
 
-When set to `true`, the build will also generate a `manifest.json` file that contains a mapping of non-hashed asset filenames to their hashed versions, which can then be used by a server framework to render the correct asset links. When the value is a string, it will be used as the manifest file name.
+When set to `true`, the build will also generate a `.vite/manifest.json` file that contains a mapping of non-hashed asset filenames to their hashed versions, which can then be used by a server framework to render the correct asset links. When the value is a string, it will be used as the manifest file name.
 
 ## build.ssrManifest
 

--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -12,7 +12,7 @@ If you need a custom integration, you can follow the steps in this guide to conf
    // vite.config.js
    export default defineConfig({
      build: {
-       // generate manifest.json in outDir
+       // generate .vite/manifest.json in outDir
        manifest: true,
        rollupOptions: {
          // overwrite default .html entry
@@ -56,7 +56,7 @@ If you need a custom integration, you can follow the steps in this guide to conf
    </script>
    ```
 
-3. For production: after running `vite build`, a `manifest.json` file will be generated alongside other asset files. An example manifest file looks like this:
+3. For production: after running `vite build`, a `.vite/manifest.json` file will be generated alongside other asset files. An example manifest file looks like this:
 
    ```json
    {

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -181,14 +181,14 @@ Refer to the [Vue](https://github.com/vitejs/vite-plugin-vue/tree/main/playgroun
 
 ## Generating Preload Directives
 
-`vite build` supports the `--ssrManifest` flag which will generate `ssr-manifest.json` in build output directory:
+`vite build` supports the `--ssrManifest` flag which will generate `.vite/ssr-manifest.json` in build output directory:
 
 ```diff
 - "build:client": "vite build --outDir dist/client",
 + "build:client": "vite build --outDir dist/client --ssrManifest",
 ```
 
-The above script will now generate `dist/client/ssr-manifest.json` for the client build (Yes, the SSR manifest is generated from the client build because we want to map module IDs to client files). The manifest contains mappings of module IDs to their associated chunks and asset files.
+The above script will now generate `dist/client/.vite/ssr-manifest.json` for the client build (Yes, the SSR manifest is generated from the client build because we want to map module IDs to client files). The manifest contains mappings of module IDs to their associated chunks and asset files.
 
 To leverage the manifest, frameworks need to provide a way to collect the module IDs of the components that were used during a server render call.
 


### PR DESCRIPTION
close #539