### PR TITLE
docs: indirect use vite.middlewares in example (#15020)

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -67,7 +67,9 @@ const vite = await createServer({
   },
 })
 
-server.use(vite.middlewares)
+server.use((req, res, next) => {
+  vite.middlewares.handle(req, res, next)
+})
 ```
 
 </details>


### PR DESCRIPTION
close #705 