### PR TITLE
fix: pass `customLogger` to `loadConfigFromFile` (fix #15824) (#15831)

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -397,6 +397,7 @@ async function loadConfigFromFile(
   configFile?: string,
   configRoot: string = process.cwd(),
   logLevel?: LogLevel,
+  customLogger?: Logger,
 ): Promise<{
   path: string
   config: UserConfig


### PR DESCRIPTION
close #797 