### PR TITLE
fix: encode URLs correctly (fix #15298) (#15311)

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -282,3 +282,5 @@ experimental: {
   }
 }
 ```
+
+Note that the `filename` passed is a decoded URL, and if the function returns a URL string, it should also be decoded. Vite will handle the encoding automatically when rendering the URLs. If an object with `runtime` is returned, encoding should be handled yourself where needed as the runtime code will be rendered as is.


### PR DESCRIPTION
close #866 