### PR TITLE
docs: fix a small typo in `backend-integration.md` (#16161)

### DIFF
--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -99,7 +99,7 @@ If you need a custom integration, you can follow the steps in this guide to conf
    <!-- for cssFile of manifest[name].css -->
    <link rel="stylesheet" href="/{{ cssFile }}" />
 
-   <!-- for chunk of importedChunks(manifest, name)) -->
+   <!-- for chunk of importedChunks(manifest, name) -->
    <!-- for cssFile of chunk.css -->
    <link rel="stylesheet" href="/{{ cssFile }}" />
 


### PR DESCRIPTION
close #875 