### PR TITLE
docs(shared-options): fix small typo (#17550)

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -18,7 +18,7 @@ See [Project Root](/guide/#index-html-and-project-root) for more details.
 Base public path when served in development or production. Valid values include:
 
 - Absolute URL pathname, e.g. `/foo/`
-- Full URL, e.g. `https://bar.com/foo/` (The origin part won't be used in development so the value is the same as as `/foo/`)
+- Full URL, e.g. `https://bar.com/foo/` (The origin part won't be used in development so the value is the same as `/foo/`)
 - Empty string or `./` (for embedded deployment)
 
 See [Public Base Path](/guide/build#public-base-path) for more details.


### PR DESCRIPTION
close #976 