### PR TITLE
Convert Renovate to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 100
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 100

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
## Summary

Replaces Renovate with GitHub's native Dependabot for dependency updates.

- Removed `renovate.json`
- Added `.github/dependabot.yml` covering:
  - **npm** dependencies (root)
  - **github-actions** used in workflows (root)

## Configuration

- **Schedule:** `daily` for both ecosystems
- **Open pull requests limit:** `100` per ecosystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FcFzNDuoXSM8uPAzwaKb54

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcFzNDuoXSM8uPAzwaKb54)_